### PR TITLE
Image Recognition fix: ImageSource json value should be"source", not "image"

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -57,7 +57,7 @@ type Message struct {
 type MessageContent struct {
 	Type  ContentType  `json:"type,omitempty"`
 	Text  *string      `json:"text,omitempty"`
-	Image *ImageSource `json:"image,omitempty"`
+	Image *ImageSource `json:"source,omitempty"`
 }
 
 // ImageSource describes an image that is sent to the model in base64 (type).


### PR DESCRIPTION
https://docs.anthropic.com/claude/reference/messages_post

Starting with Claude 3 models, you can also send image content blocks:
```
{"role": "user", "content": [
  {
    "type": "image",
    "source": {
      "type": "base64",
      "media_type": "image/jpeg",
      "data": "/9j/4AAQSkZJRg...",
    }
  },
  {"type": "text", "text": "What is in this image?"}
]}
```